### PR TITLE
Use file paths when converting .json to .po

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 node_modules
 coverage
 npm-debug.log
-/lib
-/bin

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+'use strict';
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+var Promise = require('bluebird');
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var program = require('commander');
+
+var _require = require('chalk');
+
+var red = _require.red;
+var green = _require.green;
+var blue = _require.blue;
+var yellow = _require.yellow;
+
+
+var i18nextConv = require('../lib');
+var plurals = require('../lib/plurals');
+
+var writeFileAsync = Promise.promisify(fs.writeFile);
+var readFileAsync = Promise.promisify(fs.readFile);
+var gettextToI18next = i18nextConv.gettextToI18next;
+var i18nextToPo = i18nextConv.i18nextToPo;
+var i18nextToPot = i18nextConv.i18nextToPot;
+var i18nextToMo = i18nextConv.i18nextToMo;
+
+// test calls:
+
+// gettext -> i18next
+// node bin -l en -s ./test/_testfiles/en/translation.utf8.po -t ./test/_tmp/en.json
+// node bin -l de -s ./test/_testfiles/de/translation.utf8.po -t ./test/_tmp/de.json
+// node bin -l ru -s ./test/_testfiles/ru/translation.utf8.po -t ./test/_tmp/ru.json
+
+// With filter:
+// node bin -l en -s ./test/_testfiles/en/translation.utf8.po -t ./test/_tmp/en.json -f path/to/filter.js
+
+// i18next -> gettext
+// node bin -l de -s ./test/_testfiles/de/translation.utf8.json -t ./test/_tmp/de.po
+// and back
+// node bin -l de -s ./test/_tmp/de.po -t ./test/_tmp/de.json
+
+// program
+
+program.version(i18nextConv.version).option('-b, --base [path]', 'Sepcify path for the base language file. only take effect with -K option', '').option('-f, --filter [path]', 'Specify path to gettext filter').option('-l, --language [domain]', 'Specify the language code, eg. \'en\'').option('-p, --pot', 'Generate POT file.').option('-s, --source [path]', 'Specify path to read from').option('-t, --target [path]', 'Specify path to write to', '').option('-K, --keyasareference', 'Deal with the reference comment as a key', false).option('-ks, --keyseparator [path]', 'Specify keyseparator you want to use, defaults to ##', '##').option('-P, --plurals [path]', 'Specify path to plural forms definitions').option('--quiet', 'Silence output', false).option('--skipUntranslated', 'Skip untranslated keys when converting into json', false).option('--splitNewLine', 'Silence output', false).option('--ctxSeparator [sep]', 'Specify the context separator', '_').option('--ignorePlurals', 'Do not process the plurals').parse(process.argv);
+
+var source = program.source;
+var target = program.target;
+var filter = program.filter;
+
+var options = _objectWithoutProperties(program, ['source', 'target', 'filter']);
+
+if (filter && fs.existsSync(filter)) {
+  options.filter = require(filter); // eslint-disable-line global-require
+}
+
+if (base && fs.existsSync(base)) {
+  options.base = fs.readFileSync(base);
+}
+
+var language = options.language;
+var pot = options.pot;
+var base = options.base;
+
+
+if (source && language) {
+  if (pot && !base) {
+    console.log(red('at least call with argument -p and -b.'));
+    console.log('(call program with argument -h for help.)');
+    process.exit();
+  }
+
+  if (!options.quiet) console.log(yellow('start converting'));
+
+  processFile(language, source, target, options).then(function () {
+    if (!options.quiet) console.log(green('file written'));
+  }).catch(function () /* err */{
+    console.log(red('failed writing file'));
+  });
+} else {
+  console.log(red('at least call with argument -l and -s.'));
+  console.log('(call program with argument -h for help.)');
+}
+
+function processFile(domain, source, target, options) {
+  if (!options.quiet) console.log('--> reading file from: ' + source);
+
+  return readFileAsync(source).then(function (body) {
+    var dirname = path.dirname(source);
+    var ext = path.extname(source);
+    var filename = path.basename(source, ext);
+
+    if (options.plurals) {
+      var pluralsPath = path.join(process.cwd(), options.plurals);
+      plurals.rules = require(pluralsPath); // eslint-disable-line global-require
+
+      if (!options.quiet) console.log(blue('use custom plural forms ' + pluralsPath));
+    }
+
+    var targetDir = void 0;
+    var targetExt = void 0;
+    var converter = void 0;
+
+    if (!target) {
+      targetDir = dirname.lastIndexOf(domain) === 0 ? dirname : path.join(dirname, domain);
+      targetExt = ext === '.json' ? '.po' : '.json';
+      target = path.join(targetDir, '' + filename + targetExt);
+    } else {
+      targetDir = path.dirname(target);
+      targetExt = path.extname(target);
+    }
+
+    switch (targetExt) {
+      case '.po':
+        converter = i18nextToPo;
+        break;
+      case '.pot':
+        converter = i18nextToPot;
+        break;
+      case '.mo':
+        converter = i18nextToMo;
+        break;
+      case '.json':
+        converter = gettextToI18next;
+        break;
+      default:
+        return null;
+    }
+
+    if (!fs.existsSync(targetDir)) {
+      mkdirp.sync(targetDir);
+    }
+
+    return converter(domain, body, options);
+  }).then(function (data) {
+    return writeFile(target, data, options);
+  }).catch(function (err) {
+    if (err.code === 'ENOENT') console.log(red('file ' + source + ' was not found.'));
+  });
+}
+
+function writeFile(target, data) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  if (!options.quiet) console.log('<-- writing file to: ' + target);
+
+  return writeFileAsync(target, data);
+}

--- a/lib/flatten.js
+++ b/lib/flatten.js
@@ -1,0 +1,133 @@
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+function regexIndexOf(value, regex, startpos) {
+  var indexOf = value.substring(startpos || 0).search(regex);
+  return indexOf >= 0 ? indexOf + (startpos || 0) : indexOf;
+}
+
+module.exports = {
+  flatten: function flatten(input) {
+    var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    var _ref$keyseparator = _ref.keyseparator;
+    var keyseparator = _ref$keyseparator === undefined ? '##' : _ref$keyseparator;
+    var _ref$ctxSeparator = _ref.ctxSeparator;
+    var ctxSeparator = _ref$ctxSeparator === undefined ? '_' : _ref$ctxSeparator;
+    var ignorePlurals = _ref.ignorePlurals;
+
+    var flat = {};
+
+    function recurse(appendTo, obj, parentKey) {
+      Object.keys(obj).forEach(function (m) {
+        var kv = void 0;
+        var key = parentKey;
+        var context = '';
+        var value = obj[m];
+
+        if (key.length > 0) {
+          key = key + keyseparator + m;
+        } else {
+          key = m;
+        }
+
+        // get context if used
+        var pluralIndex = key.indexOf('_plural');
+        if (pluralIndex < 0) pluralIndex = regexIndexOf(key, /_\d+$/);
+
+        var isPlural = pluralIndex > -1;
+        if (ignorePlurals) {
+          isPlural = false;
+        }
+
+        var number = void 0;
+        if (isPlural && key.indexOf('_plural') < 0) {
+          number = parseInt(key.substring(pluralIndex + 1), 10);
+          if (number === 1) {
+            isPlural = false;
+          }
+          key = key.substring(0, pluralIndex);
+        } else if (key.indexOf('_plural') > -1) {
+          number = 2;
+          key = key.substring(0, pluralIndex);
+        }
+
+        var ctxKey = key;
+
+        if (isPlural) {
+          ctxKey = ctxKey.substring(0, pluralIndex);
+          if (ctxKey.indexOf(ctxSeparator) > -1) {
+            context = ctxKey.substring(ctxKey.lastIndexOf(ctxSeparator) + ctxSeparator.length, ctxKey.length);
+          }
+        } else if (key.indexOf(ctxSeparator) > -1) {
+          context = ctxKey.substring(ctxKey.lastIndexOf(ctxSeparator) + ctxSeparator.length, ctxKey.length);
+        } else {
+          context = '';
+        }
+
+        if (context === key) context = '';
+
+        if (context !== '') key = key.replace(ctxSeparator + context, '');
+
+        // append or recurse
+        var appendKey = key + context;
+        if (isPlural) appendKey = appendKey + '_' + number;
+        if (typeof value === 'string') {
+          kv = {
+            // id: key.replace(new RegExp(' ', 'g'), ''),
+            key: key,
+            value: value,
+            isPlural: isPlural,
+            pluralNumber: isPlural ? number : 0,
+            context: context
+          };
+          appendTo[appendKey] = kv;
+        } else if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && typeof value.msgstr === 'string' && Array.isArray(value.paths)) {
+          kv = {
+            key: key,
+            value: value.msgstr,
+            isPlural: isPlural,
+            pluralNumber: isPlural ? number : 0,
+            context: context,
+            paths: value.paths
+          };
+          appendTo[appendKey] = kv;
+        } else if (Array.isArray(value)) {
+          kv = {
+            // id: key.replace(new RegExp(' ', 'g'), ''),
+            key: key,
+            value: value.join('\n'),
+            isArray: true,
+            isPlural: isPlural,
+            pluralNumber: isPlural ? number : 0,
+            context: context
+          };
+          appendTo[appendKey] = kv;
+        } else {
+          recurse(appendTo, value, key);
+        }
+      });
+    }
+
+    recurse(flat, input, '');
+
+    // append plurals
+    Object.keys(flat).forEach(function (m) {
+      var kv = flat[m];
+
+      if (kv.isPlural) {
+        var single = flat[kv.key + kv.context];
+
+        if (single) {
+          single.plurals = single.plurals || [];
+          single.plurals.push(kv);
+
+          delete flat[m];
+        }
+      }
+    });
+
+    return flat;
+  }
+};

--- a/lib/gettext2json.js
+++ b/lib/gettext2json.js
@@ -1,0 +1,174 @@
+'use strict';
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var Gettext = require('node-gettext');
+var Promise = require('bluebird');
+var assign = require('object-assign'); // Support node <= 0.12
+
+var plurals = require('./plurals');
+
+function gettextToI18next(domain, body) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  return addTextDomain(domain, body, options).then(function (data) {
+    if (options.keyasareference) {
+      setKeysAsReference(data);
+    }
+
+    return parseJSON(domain, data, options);
+  }).then(function (json) {
+    return JSON.stringify(json, null, 4);
+  });
+}
+
+/*
+ * gettext --> barebone json
+ */
+function addTextDomain(domain, body) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  var gt = new Gettext();
+
+  if (body.length > 0) {
+    gt.addTextdomain(domain, body);
+  }
+
+  if (options.filter) {
+    var filterAsync = Promise.promisify(options.filter);
+    return filterAsync(gt, domain);
+  }
+
+  var normalizedDomain = gt._normalizeDomain(domain);
+  return Promise.resolve(gt.domains[normalizedDomain] && gt.domains[normalizedDomain].translations);
+}
+
+function setKeysAsReference(data) {
+  var keys = [];
+
+  Object.keys(data).forEach(function (ctxt) {
+    Object.keys(data[ctxt]).forEach(function (key) {
+      if (data[ctxt][key].comments && data[ctxt][key].comments.reference) {
+        data[ctxt][key].comments.reference.split(/\r?\n|\r/).forEach(function (id) {
+          var x = data[ctxt][key];
+          data[ctxt][id] = x;
+          if (x.msgstr[0] === '') {
+            x.msgstr[0] = x.msgid;
+          }
+          for (var i = 1; i < x.msgstr.length; i++) {
+            if (x.msgstr[i] === '') {
+              x.msgstr[i] = x.msgid_plural;
+            }
+          }
+          x.msgid = id;
+          if (id !== key) {
+            keys.push([ctxt, key]);
+          }
+        });
+      }
+    });
+  });
+
+  keys.forEach(function (a) {
+    var c = a[0];
+    var k = a[1];
+
+    delete data[c][k];
+  });
+}
+
+/*
+ * barebone json --> i18next json
+ */
+function parseJSON(domain) {
+  var data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  var separator = options.keyseparator || '##';
+  var json = {};
+  var ctxSeparator = options.ctxSeparator || '_';
+
+  Object.keys(data).forEach(function (m) {
+    var context = data[m];
+
+    Object.keys(context).forEach(function (key) {
+      var targetKey = key;
+      var appendTo = json;
+
+      if (key.length === 0) {
+        // delete if msgid is empty.
+        // this might be the header.
+        delete context[key];
+        return;
+      }
+
+      if (key.indexOf(separator) > -1) {
+        var keys = key.split(separator);
+
+        var x = 0;
+        while (keys[x]) {
+          if (x < keys.length - 1) {
+            appendTo[keys[x]] = appendTo[keys[x]] || {};
+            appendTo = appendTo[keys[x]];
+          } else {
+            targetKey = keys[x];
+          }
+          x++;
+        }
+      }
+
+      if (m !== '') targetKey = '' + targetKey + ctxSeparator + m;
+
+      var values = context[key].msgstr;
+      var newValues = getGettextValues(values, domain, targetKey, options);
+      assign(appendTo, newValues);
+    });
+  });
+
+  return Promise.resolve(json);
+}
+
+function getGettextValues(values, domain, targetKey, options) {
+  if (values.length === 1) {
+    return emptyOrObject(targetKey, values[0], options);
+  }
+
+  var ext = plurals.rules[domain.replace('_', '-').split('-')[0]];
+  var gettextValues = {};
+
+  for (var i = 0; i < values.length; i++) {
+    var pluralSuffix = getI18nextPluralExtension(ext, i);
+    var pkey = targetKey + pluralSuffix;
+
+    assign(gettextValues, emptyOrObject(pkey, values[i], options));
+  }
+
+  return gettextValues;
+}
+
+/*
+ * helper to get plural suffix
+ */
+function getI18nextPluralExtension(ext, i) {
+  if (ext && ext.nplurals === 2) {
+    return i === 0 ? '' : '_plural';
+  }
+  return '_' + i;
+}
+
+function toArrayIfNeeded(value, _ref) {
+  var splitNewLine = _ref.splitNewLine;
+
+  return value.indexOf('\n') > -1 && splitNewLine ? value.split('\n') : value;
+}
+
+function emptyOrObject(key, value, options) {
+  if (options.skipUntranslated && !value) {
+    // empty string or other falsey
+    return {};
+  }
+
+  return _defineProperty({}, key, toArrayIfNeeded(value, options));
+}
+
+module.exports = gettextToI18next;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var pkginfo = require('pkginfo');
+var gettextToI18next = require('./gettext2json');
+
+var _require = require('./json2gettext');
+
+var i18nextToPo = _require.i18nextToPo;
+var i18nextToPot = _require.i18nextToPot;
+var i18nextToMo = _require.i18nextToMo;
+
+
+module.exports = {
+  gettextToI18next: gettextToI18next,
+  i18nextToPo: i18nextToPo,
+  i18nextToPot: i18nextToPot,
+  i18nextToMo: i18nextToMo
+};
+
+pkginfo(module, ['version']);

--- a/lib/json2gettext.js
+++ b/lib/json2gettext.js
@@ -1,0 +1,231 @@
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var GettextParser = require('gettext-parser');
+var Promise = require('bluebird');
+
+var plurals = require('./plurals');
+
+var _require = require('./flatten');
+
+var flatten = _require.flatten;
+
+
+function i18nextToPo(domain, body) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  return i18nextToGettext(domain, body, GettextParser.po, identity, options);
+}
+
+function i18nextToPot(domain, body) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  return i18nextToGettext(domain, body, GettextParser.po, function () {
+    return '';
+  }, options);
+}
+
+function i18nextToMo(domain, body) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  return i18nextToGettext(domain, body, GettextParser.mo, identity, options);
+}
+
+function i18nextToGettext(domain, body, parser, getTranslatedValue) {
+  var options = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
+
+  return Promise.resolve(flatten(JSON.parse(body), options)).then(function (flat) {
+    if (options.base) {
+      var _ret = function () {
+        var bflat = flatten(JSON.parse(options.base), options);
+        Object.keys(bflat).forEach(function (key) {
+          if (flat[key]) {
+            if (flat[key].plurals) {
+              bflat[key].translated_value = getTranslatedValue(getPluralArray(domain, flat[key]));
+            } else {
+              bflat[key].translated_value = getTranslatedValue(flat[key].value);
+            }
+          }
+        });
+
+        return {
+          v: parseGettext(domain, bflat, options)
+        };
+      }();
+
+      if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+    }
+
+    return parseGettext(domain, flat, options);
+  }).then(function (data) {
+    return parser.compile(data);
+  });
+}
+
+function getPluralArray(domain, translation) {
+  var ext = plurals.rules[domain.replace('_', '-').split('-')[0]];
+  var pArray = [];
+
+  for (var i = 0, len = translation.plurals.length; i < len; i++) {
+    var plural = translation.plurals[i];
+    pArray.splice(getGettextPluralPosition(ext, plural.pluralNumber - 1), 0, plural.value);
+  }
+  pArray.splice(getGettextPluralPosition(ext, translation.pluralNumber - 1), 0, translation.value);
+
+  return pArray;
+}
+
+/*
+ * flat json --> gettext
+ */
+function parseGettext(domain, data) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  var out = {
+    charset: 'utf-8',
+    headers: {
+      'project-id-version': options.project || 'i18next-conv',
+      'mime-version': '1.0',
+      'content-type': 'text/plain; charset=utf-8',
+      'content-transfer-encoding': '8bit'
+    },
+    translations: {}
+  };
+
+  var ext = plurals.rules[domain.replace('_', '-').split('-')[0]];
+  var trans = {};
+
+  out.headers['plural-forms'] = 'nplurals=' + ext.nplurals + '; ' + ('plural=' + ext.plurals);
+
+  if (!options.noDate) {
+    out.headers['pot-creation-date'] = new Date().toISOString();
+    out.headers['po-revision-date'] = new Date().toISOString();
+  }
+  if (options.language) {
+    out.headers.language = options.language;
+  }
+  var delkeys = [];
+
+  Object.keys(data).forEach(function (m) {
+    var kv = data[m];
+    var kvPosition = void 0;
+
+    if (kv.plurals) {
+      var pArray = [];
+
+      for (var i = 0, len = kv.plurals.length; i < len; i++) {
+        var plural = kv.plurals[i];
+        pArray.splice(getGettextPluralPosition(ext, plural.pluralNumber - 1), 0, plural.value);
+      }
+      pArray.splice(getGettextPluralPosition(ext, kv.pluralNumber - 1), 0, kv.value);
+
+      if (_typeof(trans[kv.context]) !== 'object') trans[kv.context] = {};
+      if (options.keyasareference) {
+        if (_typeof(trans[kv.context][kv.value]) === 'object') {
+          // same context and msgid. this could theorically be merged.
+          trans[kv.context][kv.value].comments.reference.push(kv.key);
+          kvPosition = kv.value;
+        } else {
+          trans[kv.context][kv.value] = {
+            msgctxt: kv.context,
+            msgid: pArray[0],
+            msgid_plural: pArray.slice(1, pArray.length),
+            msgstr: kv.translated_value,
+            comments: { reference: [kv.key] }
+          };
+          kvPosition = kv.value;
+        }
+        if (kv.key !== kv.value) {
+          delkeys.push([kv.context, kv.key]);
+        }
+      } else {
+        trans[kv.context][kv.key] = {
+          msgctxt: kv.context,
+          msgid: kv.key,
+          msgid_plural: kv.key,
+          msgstr: pArray
+        };
+        kvPosition = kv.key;
+      }
+    } else {
+      if (_typeof(trans[kv.context]) !== 'object') trans[kv.context] = {};
+
+      if (options.keyasareference) {
+        if (_typeof(trans[kv.context][kv.value]) === 'object') {
+          // same context and msgid. this could theorically be merged.
+          trans[kv.context][kv.value].comments.reference.push(kv.key);
+          kvPosition = kv.value;
+        } else {
+          trans[kv.context][kv.value] = {
+            msgctxt: kv.context,
+            msgid: kv.value,
+            msgstr: kv.translated_value,
+            comments: {
+              reference: [kv.key]
+            }
+          };
+          kvPosition = kv.value;
+        }
+        if (kv.key !== kv.value) {
+          delkeys.push([kv.context, kv.key]);
+        }
+      } else {
+        trans[kv.context][kv.key] = { msgctxt: kv.context, msgid: kv.key, msgstr: kv.value };
+        kvPosition = kv.key;
+      }
+    }
+
+    // add file paths to comment references
+    if (kv.paths) {
+      if (trans[kv.context][kvPosition].comments && trans[kv.context][kvPosition].comments.reference) {
+        trans[kv.context][kvPosition].comments.reference = trans[kv.context][kvPosition].comments.reference.concat(kv.paths);
+      } else {
+        trans[kv.context][kvPosition].comments = { reference: kv.paths };
+      }
+    }
+  });
+
+  delkeys.forEach(function (a) {
+    var c = a[0];
+    var k = a[1];
+    delete trans[c][k];
+  });
+
+  // re-format reference comments to be able to compile with gettext-parser...
+  Object.keys(trans).forEach(function (ctxt) {
+    Object.keys(trans[ctxt]).forEach(function (id) {
+      if (trans[ctxt][id].comments && trans[ctxt][id].comments.reference) {
+        trans[ctxt][id].comments.reference = trans[ctxt][id].comments.reference.join('\n');
+      }
+    });
+  });
+
+  out.translations = trans;
+  return Promise.resolve(out);
+}
+
+/*
+ * helper to get plural suffix
+ */
+function getGettextPluralPosition(ext, suffix) {
+  if (ext) {
+    for (var i = 0; i < ext.nplurals; i++) {
+      if (i === suffix) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function identity(val) {
+  return val;
+}
+
+module.exports = {
+  i18nextToPot: i18nextToPot,
+  i18nextToPo: i18nextToPo,
+  i18nextToMo: i18nextToMo
+};

--- a/lib/plurals.js
+++ b/lib/plurals.js
@@ -1,0 +1,667 @@
+'use strict';
+
+// definition http://translate.sourceforge.net/wiki/l10n/pluralforms
+module.exports = {
+  rules: {
+    ach: {
+      name: 'Acholi',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    af: {
+      name: 'Afrikaans',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ak: {
+      name: 'Akan',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    am: {
+      name: 'Amharic',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    an: {
+      name: 'Aragonese',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ar: {
+      name: 'Arabic',
+      nplurals: 6,
+      plurals: '(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5)'
+    },
+    arn: {
+      name: 'Mapudungun',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    ast: {
+      name: 'Asturian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ay: {
+      name: 'Aymará',
+      nplurals: 1,
+      plurals: '0'
+    },
+    az: {
+      name: 'Azerbaijani',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    be: {
+      name: 'Belarusian',
+      nplurals: 3,
+      plurals: '(n%10== 1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+    },
+    bg: {
+      name: 'Bulgarian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    bn: {
+      name: 'Bengali',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    bo: {
+      name: 'Tibetan',
+      nplurals: 1,
+      plurals: '0'
+    },
+    br: {
+      name: 'Breton',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    brx: {
+      name: 'Bodo',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    bs: {
+      name: 'Bosnian',
+      nplurals: 3,
+      plurals: '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+    },
+    ca: {
+      name: 'Catalan',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    cgg: {
+      name: 'Chiga',
+      nplurals: 1,
+      plurals: '0'
+    },
+    cs: {
+      name: 'Czech',
+      nplurals: 3,
+      plurals: '(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2'
+    },
+    csb: {
+      name: 'Kashubian',
+      nplurals: 3,
+      plurals: '(n==1) ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2'
+    },
+    cy: {
+      name: 'Welsh',
+      nplurals: 4,
+      plurals: '(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3'
+    },
+    da: {
+      name: 'Danish',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    de: {
+      name: 'German',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    doi: {
+      name: 'Dogri',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    dz: {
+      name: 'Dzongkha',
+      nplurals: 1,
+      plurals: '0'
+    },
+    el: {
+      name: 'Greek',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    en: {
+      name: 'English',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    eo: {
+      name: 'Esperanto',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    es: {
+      name: 'Spanish',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    es_ar: {
+      name: 'Argentinean Spanish',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    et: {
+      name: 'Estonian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    eu: {
+      name: 'Basque',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    fa: {
+      name: 'Persian',
+      nplurals: 1,
+      plurals: '0'
+    },
+    fi: {
+      name: 'Finnish',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    fil: {
+      name: 'Filipino',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    fo: {
+      name: 'Faroese',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    fr: {
+      name: 'French',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    fur: {
+      name: 'Friulian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    fy: {
+      name: 'Frisian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ga: {
+      name: 'Irish',
+      nplurals: 5,
+      plurals: 'n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :(n>6 && n<11) ? 3 : 4'
+    },
+    gd: {
+      name: 'Scottish Gaelic',
+      nplurals: 4,
+      plurals: '(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3'
+    },
+    gl: {
+      name: 'Galician',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    gu: {
+      name: 'Gujarati',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    gun: {
+      name: 'Gun',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    ha: {
+      name: 'Hausa',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    he: {
+      name: 'Hebrew',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    hi: {
+      name: 'Hindi',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    hr: {
+      name: 'Croatian',
+      nplurals: 3,
+      plurals: '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+    },
+    hu: {
+      name: 'Hungarian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    hy: {
+      name: 'Armenian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ia: {
+      name: 'Interlingua',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    id: {
+      name: 'Indonesian',
+      nplurals: 1,
+      plurals: '0'
+    },
+    is: {
+      name: 'Icelandic',
+      nplurals: 2,
+      plurals: '(n%10!=1 || n%100==11)'
+    },
+    it: {
+      name: 'Italian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ja: {
+      name: 'Japanese',
+      nplurals: 1,
+      plurals: '0'
+    },
+    jbo: {
+      name: 'Lojban',
+      nplurals: 1,
+      plurals: '0'
+    },
+    jv: {
+      name: 'Javanese',
+      nplurals: 2,
+      plurals: '(n != 0)'
+    },
+    ka: {
+      name: 'Georgian',
+      nplurals: 1,
+      plurals: '0'
+    },
+    kk: {
+      name: 'Kazakh',
+      nplurals: 1,
+      plurals: '0'
+    },
+    km: {
+      name: 'Khmer',
+      nplurals: 1,
+      plurals: '0'
+    },
+    kn: {
+      name: 'Kannada',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ko: {
+      name: 'Korean',
+      nplurals: 1,
+      plurals: '0'
+    },
+    ku: {
+      name: 'Kurdish',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    kw: {
+      name: 'Cornish',
+      nplurals: 4,
+      plurals: '(n==1) ? 0 : (n==2) ? 1 : (n==3) ? 2 : 3'
+    },
+    ky: {
+      name: 'Kyrgyz',
+      nplurals: 1,
+      plurals: '0'
+    },
+    lb: {
+      name: 'Letzeburgesch',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ln: {
+      name: 'Lingala',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    lo: {
+      name: 'Lao',
+      nplurals: 1,
+      plurals: '0'
+    },
+    lt: {
+      name: 'Lithuanian',
+      nplurals: 3,
+      plurals: '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2)'
+    },
+    lv: {
+      name: 'Latvian',
+      nplurals: 3,
+      plurals: '(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2)'
+    },
+    mai: {
+      name: 'Maithili',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    mfe: {
+      name: 'Mauritian Creole',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    mg: {
+      name: 'Malagasy',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    mi: {
+      name: 'Maori',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    mk: {
+      name: 'Macedonian',
+      nplurals: 2,
+      plurals: 'n==1 || n%10==1 ? 0 : 1'
+    },
+    ml: {
+      name: 'Malayalam',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    mn: {
+      name: 'Mongolian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    mnk: {
+      name: 'Mandinka',
+      nplurals: 3,
+      plurals: '(n==0 ? 0 : n==1 ? 1 : 2)'
+    },
+    mr: {
+      name: 'Marathi',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ms: {
+      name: 'Malay',
+      nplurals: 1,
+      plurals: '0'
+    },
+    mt: {
+      name: 'Maltese',
+      nplurals: 4,
+      plurals: '(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3)'
+    },
+    nah: {
+      name: 'Nahuatl',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    nap: {
+      name: 'Neapolitan',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    nb: {
+      name: 'Norwegian Bokmal',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ne: {
+      name: 'Nepali',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    nl: {
+      name: 'Dutch',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    nn: {
+      name: 'Norwegian Nynorsk',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    no: {
+      name: 'Norwegian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    nso: {
+      name: 'Northern Sotho',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    oc: {
+      name: 'Occitan',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    or: {
+      name: 'Oriya',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    pa: {
+      name: 'Punjabi',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    pap: {
+      name: 'Papiamento',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    pl: {
+      name: 'Polish',
+      nplurals: 3,
+      plurals: '(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+    },
+    pms: {
+      name: 'Piemontese',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ps: {
+      name: 'Pashto',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    pt: {
+      name: 'Portuguese',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    pt_br: {
+      name: 'Brazilian Portuguese',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    rm: {
+      name: 'Romansh',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ro: {
+      name: 'Romanian',
+      nplurals: 3,
+      plurals: '(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2)'
+    },
+    ru: {
+      name: 'Russian',
+      nplurals: 3,
+      plurals: '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+    },
+    sah: {
+      name: 'Yakut',
+      nplurals: 1,
+      plurals: '0'
+    },
+    sco: {
+      name: 'Scots',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    se: {
+      name: 'Northern Sami',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    si: {
+      name: 'Sinhala',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    sk: {
+      name: 'Slovak',
+      nplurals: 3,
+      plurals: '(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2'
+    },
+    sl: {
+      name: 'Slovenian',
+      nplurals: 4,
+      plurals: '(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0)'
+    },
+    so: {
+      name: 'Somali',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    son: {
+      name: 'Songhay',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    sq: {
+      name: 'Albanian',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    sr: {
+      name: 'Serbian',
+      nplurals: 3,
+      plurals: '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+    },
+    su: {
+      name: 'Sundanese',
+      nplurals: 1,
+      plurals: '0'
+    },
+    sv: {
+      name: 'Swedish',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    sw: {
+      name: 'Swahili',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    ta: {
+      name: 'Tamil',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    te: {
+      name: 'Telugu',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    tg: {
+      name: 'Tajik',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    th: {
+      name: 'Thai',
+      nplurals: 1,
+      plurals: '0'
+    },
+    ti: {
+      name: 'Tigrinya',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    tk: {
+      name: 'Turkmen',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    tr: {
+      name: 'Turkish',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    tt: {
+      name: 'Tatar',
+      nplurals: 1,
+      plurals: '0'
+    },
+    ug: {
+      name: 'Uyghur',
+      nplurals: 1,
+      plurals: '0'
+    },
+    uk: {
+      name: 'Ukrainian',
+      nplurals: 3,
+      plurals: '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+    },
+    ur: {
+      name: 'Urdu',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    uz: {
+      name: 'Uzbek',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    vi: {
+      name: 'Vietnamese',
+      nplurals: 1,
+      plurals: '0'
+    },
+    wa: {
+      name: 'Walloon',
+      nplurals: 2,
+      plurals: '(n > 1)'
+    },
+    wo: {
+      name: 'Wolof',
+      nplurals: 1,
+      plurals: '0'
+    },
+    yo: {
+      name: 'Yoruba',
+      nplurals: 2,
+      plurals: '(n != 1)'
+    },
+    zh: {
+      name: 'Chinese',
+      nplurals: 1,
+      plurals: '0'
+    }
+  }
+};

--- a/src/lib/flatten.js
+++ b/src/lib/flatten.js
@@ -75,6 +75,16 @@ module.exports = {
             context,
           };
           appendTo[appendKey] = kv;
+        } else if (typeof value === 'object' && typeof value.msgstr === 'string' && Array.isArray(value.paths)) {
+          kv = {
+            key,
+            value: value.msgstr,
+            isPlural,
+            pluralNumber: isPlural ? number : 0,
+            context,
+            paths: value.paths,
+          };
+          appendTo[appendKey] = kv;
         } else if (Array.isArray(value)) {
           kv = {
             // id: key.replace(new RegExp(' ', 'g'), ''),

--- a/src/lib/json2gettext.js
+++ b/src/lib/json2gettext.js
@@ -85,6 +85,7 @@ function parseGettext(domain, data, options = {}) {
 
   Object.keys(data).forEach(m => {
     const kv = data[m];
+    let kvPosition;
 
     if (kv.plurals) {
       const pArray = [];
@@ -98,8 +99,9 @@ function parseGettext(domain, data, options = {}) {
       if (typeof trans[kv.context] !== 'object') trans[kv.context] = {};
       if (options.keyasareference) {
         if (typeof trans[kv.context][kv.value] === 'object') {
-                      // same context and msgid. this could theorically be merged.
+          // same context and msgid. this could theorically be merged.
           trans[kv.context][kv.value].comments.reference.push(kv.key);
+          kvPosition = kv.value;
         } else {
           trans[kv.context][kv.value] = {
             msgctxt: kv.context,
@@ -108,6 +110,7 @@ function parseGettext(domain, data, options = {}) {
             msgstr: kv.translated_value,
             comments: { reference: [kv.key] },
           };
+          kvPosition = kv.value;
         }
         if (kv.key !== kv.value) {
           delkeys.push([kv.context, kv.key]);
@@ -119,6 +122,7 @@ function parseGettext(domain, data, options = {}) {
           msgid_plural: kv.key,
           msgstr: pArray,
         };
+        kvPosition = kv.key;
       }
     } else {
       if (typeof trans[kv.context] !== 'object') trans[kv.context] = {};
@@ -127,6 +131,7 @@ function parseGettext(domain, data, options = {}) {
         if (typeof trans[kv.context][kv.value] === 'object') {
           // same context and msgid. this could theorically be merged.
           trans[kv.context][kv.value].comments.reference.push(kv.key);
+          kvPosition = kv.value;
         } else {
           trans[kv.context][kv.value] = {
             msgctxt: kv.context,
@@ -136,12 +141,23 @@ function parseGettext(domain, data, options = {}) {
               reference: [kv.key],
             },
           };
+          kvPosition = kv.value;
         }
         if (kv.key !== kv.value) {
           delkeys.push([kv.context, kv.key]);
         }
       } else {
         trans[kv.context][kv.key] = { msgctxt: kv.context, msgid: kv.key, msgstr: kv.value };
+        kvPosition = kv.key;
+      }
+    }
+
+    // add file paths to comment references
+    if (kv.paths) {
+      if (trans[kv.context][kvPosition].comments && trans[kv.context][kvPosition].comments.reference) {
+        trans[kv.context][kvPosition].comments.reference = trans[kv.context][kvPosition].comments.reference.concat(kv.paths);
+      } else {
+        trans[kv.context][kvPosition].comments = { reference: kv.paths };
       }
     }
   });

--- a/test/_testfiles/en/translation.file_paths.json
+++ b/test/_testfiles/en/translation.file_paths.json
@@ -1,0 +1,25 @@
+{
+  " ": {
+    "msgstr": "white space test",
+    "paths": ["fake/path/index.html"]
+  },
+  "yasss queen": {
+    "msgstr": "",
+    "paths": ["fake/path/template.hbs", "fake/path/partial.hbs"]
+  },
+  "a": {
+    "apple": {
+      "msgstr": "I have an apple",
+      "paths": ["./test/fakepath/zero.jade", "./test/fakepath/one.jade", "./test/fakepath/two.jade"]
+    },
+    "apple_plural": "I have {count} apples",
+    "apple_negative": "I have no apples"
+  },
+  "friend_female": {
+    "msgstr": "A girlfriend",
+    "paths": ["./test/_testfiles/en/translation.file_paths.json"]
+  },
+  "friend_female_plural": "{count} girlfriends",
+  "friend_nonbinary": "A partner",
+  "friend_nonbinary_plural": "{count} partners"
+}

--- a/test/_testfiles/en/translation.file_paths.po
+++ b/test/_testfiles/en/translation.file_paths.po
@@ -1,0 +1,41 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+
+#: fake/path/index.html
+msgid " "
+msgstr "white space test"
+
+#: fake/path/template.hbs
+#: fake/path/partial.hbs
+msgid "yasss queen"
+msgstr ""
+
+#: ./test/fakepath/zero.jade
+#: ./test/fakepath/one.jade
+#: ./test/fakepath/two.jade
+msgid "a##apple"
+msgid_plural "a##apple"
+msgstr[0] "I have an apple"
+msgstr[1] "I have {count} apples"
+
+msgctxt "negative"
+msgid "a##apple"
+msgstr "I have no apples"
+
+#: ./test/_testfiles/en/translation.file_paths.json
+msgctxt "female"
+msgid "friend"
+msgid_plural "friend"
+msgstr[0] "A girlfriend"
+msgstr[1] "{count} girlfriends"
+
+msgctxt "nonbinary"
+msgid "friend"
+msgid_plural "friend"
+msgstr[0] "A partner"
+msgstr[1] "{count} partners"

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,8 @@ const testFiles = {
     empty: './test/_testfiles/en/translation.empty.po',
     missing: './test/_testfiles/en/translation.missing.po',
     bad_format: './test/_testfiles/en/translation.bad_format.po.js',
+    file_paths: './test/_testfiles/en/translation.file_paths.po',
+    file_paths_expected: './test/_testfiles/en/translation.file_paths.json',
   },
 
   de: {
@@ -266,6 +268,16 @@ describe('i18next-gettext-converter', () => {
           expect(result).to.deep.equal(expected);
         }),
       ])
+    );
+
+    it('should convert a JSON file to PO with comments from file paths', () =>
+      i18nextToPo('en', readFileSync(testFiles.en.file_paths_expected), {
+        splitNewLine: true,
+        noDate: true,
+      }).then(result => {
+        const expected = readFileSync(testFiles.en.file_paths).slice(0, -1);
+        expect(result).to.deep.equal(expected);
+      })
     );
   });
 


### PR DESCRIPTION
supports: https://github.com/sourceRS/i18next-parser/pull/1

Ignore the commit 'remove need for npm prepublish step by checking in bin', this repo typically relies on NPM servers and the prepublish step to generate the code needed to run this tool's CLI functionality.

The work that will be merged into the repo itself is just the 'Use file paths when converting .json to .po' commit.
